### PR TITLE
Changing to master branch as 7_5 is merged.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,7 @@ metadata
 cookbook 'kagent', github: "karamelchef/kagent-chef", branch: "master"
 cookbook 'apache_hadoop', github: "hopshadoop/apache-hadoop-chef", branch: "master"
 cookbook 'hops', github: "hopshadoop/hops-hadoop-chef", branch: "master"
-cookbook 'ndb', github: "hopshadoop/ndb-chef", branch: "7_5"
+cookbook 'ndb', github: "hopshadoop/ndb-chef", branch: "master"
 cookbook 'hadoop_spark', github: "hopshadoop/spark-chef", branch: "master"
 cookbook 'flink', github: "hopshadoop/flink-chef", branch: "master"
 cookbook 'zeppelin', github: "hopshadoop/zeppelin-chef", branch: "master"


### PR DESCRIPTION
no branch exist in ndb chef 7_5 as it is merged.