### PR TITLE
add a log4j.properties for the log written by hopsworks dependencies

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -266,6 +266,8 @@ admin_pwd="#{domains_dir}/#{domain_name}_admin_passwd"
 password_file = "#{domains_dir}/#{domain_name}_admin_passwd"
 
 login_cnf="#{domains_dir}/#{domain_name}/config/login.conf"
+log4j_cnf="#{domains_dir}/#{domain_name}/config/log4j.properties"
+
 file "#{login_cnf}" do
    action :delete
 end
@@ -276,6 +278,17 @@ template "#{login_cnf}" do
   owner node.glassfish.user
   group node.glassfish.group
   mode "0600"
+end
+
+file "#{log4j_cnf}" do
+   action :delete
+end
+
+template "#{log4j_cnf}" do
+  cookbook 'hopsworks'
+  source "log4j.properties.erb"
+  owner node.glassfish.user
+  group node.glassfish.group
 end
 
 
@@ -658,7 +671,7 @@ template "/bin/hopsworks-2fa" do
 # Add spark log4j.properties file to HDFS. Used by Logstash.
 
 template "/tmp/log4j.properties" do
-  source "log4j.properties.erb"
+  source "app.log4j.properties.erb"
   owner node.glassfish.user
   mode 0750
   action :create

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -89,7 +89,7 @@ node.override = {
           'master_password' => node.hopsworks.master.password,
           'remote_access' => false,
           'secure' => false,
-          'jvm_options' => ["-DHADOOP_HOME=#{node.hops.dir}/hadoop", "-DHADOOP_CONF_DIR=#{node.hops.dir}/hadoop/etc/hadoop", '-Dcom.sun.enterprise.tools.admingui.NO_NETWORK=true']
+          'jvm_options' => ["-DHADOOP_HOME=#{node.hops.dir}/hadoop", "-DHADOOP_CONF_DIR=#{node.hops.dir}/hadoop/etc/hadoop", '-Dcom.sun.enterprise.tools.admingui.NO_NETWORK=true', '-Dlog4j.configuration=file:///${com.sun.aas.instanceRoot}/config/log4j.properties']
         },
         'extra_libraries' => {
           'jdbcdriver' => {

--- a/templates/default/app.log4j.properties.erb
+++ b/templates/default/app.log4j.properties.erb
@@ -1,0 +1,16 @@
+# Set everything to be logged to the console
+log4j.rootLogger=INFO,console,tcp
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+log4j.appender.tcp=org.apache.log4j.net.SocketAppender
+log4j.appender.tcp.Port=3456
+log4j.appender.tcp.RemoteHost=<%= @private_ip %>
+log4j.appender.tcp.ReconnectionDelay=10000
+log4j.appender.tcp.Application=${hopsworks.logstash.job.info}
+
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.eclipse.jetty=WARN

--- a/templates/default/log4j.properties.erb
+++ b/templates/default/log4j.properties.erb
@@ -1,16 +1,6 @@
-# Set everything to be logged to the console
-log4j.rootLogger=INFO,console,tcp
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-
-log4j.appender.tcp=org.apache.log4j.net.SocketAppender
-log4j.appender.tcp.Port=3456
-log4j.appender.tcp.RemoteHost=<%= @private_ip %>
-log4j.appender.tcp.ReconnectionDelay=10000
-log4j.appender.tcp.Application=${hopsworks.logstash.job.info}
-
-
-# Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.eclipse.jetty=WARN
+log4j.rootLogger=INFO
+log4j.appender.FILE=org.apache.log4j.RollingFileAppender 
+log4j.appender.FILE.MaxFileSize=100KB 
+log4j.appender.FILE.MaxBackupIndex=1 
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout 
+log4j.appender.FILE.layout.ConversionPattern=%d{DATE} %-5p %c{1} : %m%n 


### PR DESCRIPTION
add a log4j.properties for the log written by dependencies  such as zookeeper. This should allow us to have less noise in the glassfish logs.