### PR TITLE
Ndb backups

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -366,6 +366,15 @@ template "#{node.glassfish.domains_dir}/#{domain_name}/config/ca/intermediate/de
   action :create
 end
 
+template "#{node.glassfish.domains_dir}/#{domain_name}/bin/ndb_backup.sh" do
+  source "ndb_backup.sh.erb"
+  owner node.hopsworks.user
+  group node.glassfish.group
+  mode "754"
+  action :create
+end
+
+
 
 template "/etc/sudoers.d/glassfish" do
   source "glassfish_sudoers.erb"
@@ -376,7 +385,8 @@ template "/etc/sudoers.d/glassfish" do
                 :user => node.glassfish.user,
                 :int_sh_dir =>  "#{node.glassfish.domains_dir}/#{domain_name}/config/ca/intermediate/createusercerts.sh",
                 :delete_usercert =>  "#{node.glassfish.domains_dir}/#{domain_name}/config/ca/intermediate/deleteusercerts.sh",
-                :delete_projectcert =>  "#{node.glassfish.domains_dir}/#{domain_name}/config/ca/intermediate/deleteprojectcerts.sh"
+                :delete_projectcert =>  "#{node.glassfish.domains_dir}/#{domain_name}/config/ca/intermediate/deleteprojectcerts.sh",
+                :ndb_backup =>  "#{node.glassfish.domains_dir}/#{domain_name}/bin/ndb_backup.sh"                
               })
   action :create
 end  

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -368,7 +368,7 @@ end
 
 template "#{node.glassfish.domains_dir}/#{domain_name}/bin/ndb_backup.sh" do
   source "ndb_backup.sh.erb"
-  owner node.hopsworks.user
+  owner node.glassfish.user
   group node.glassfish.group
   mode "754"
   action :create

--- a/templates/default/glassfish_sudoers.erb
+++ b/templates/default/glassfish_sudoers.erb
@@ -2,3 +2,4 @@
 <%= @user %> ALL=NOPASSWD: <%= @delete_projectcert %>
 <%= @user %> ALL=NOPASSWD: <%= @delete_usercert %>
 <%= @user %> ALL=NOPASSWD: <%= @ndb_backup %>
+

--- a/templates/default/glassfish_sudoers.erb
+++ b/templates/default/glassfish_sudoers.erb
@@ -1,3 +1,4 @@
 <%= @user %> ALL=NOPASSWD: <%= @int_sh_dir %>
 <%= @user %> ALL=NOPASSWD: <%= @delete_projectcert %>
 <%= @user %> ALL=NOPASSWD: <%= @delete_usercert %>
+<%= @user %> ALL=NOPASSWD: <%= @ndb_backup %>

--- a/templates/default/ndb_backup.sh.erb
+++ b/templates/default/ndb_backup.sh.erb
@@ -10,10 +10,17 @@ if [ $# -ne 2  ]; then
     help
 fi
 
+# Check that $2 is an int (and not some injection attack)
+re='^[0-9]+$'
+if ! [[ $2 =~ $re ]] ; then
+    echo "error: Not a number" >&2
+    help
+fi
+
 if [ "$1" = "backup" ] ; then
-    <%= node.ndb.scripts_dir %>/bin/backup-start.sh $2
+    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/bin/backup-start.sh $2"
 elif [ "$1" = "restore" ] ; then
-    <%= node.ndb.scripts_dir %>/bin/backup-restore.sh $2    
+    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/bin/backup-restore.sh $2"
 else
     help
 fi

--- a/templates/default/ndb_backup.sh.erb
+++ b/templates/default/ndb_backup.sh.erb
@@ -18,9 +18,9 @@ if ! [[ $2 =~ $re ]] ; then
 fi
 
 if [ "$1" = "backup" ] ; then
-    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/bin/backup-start.sh $2"
+    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/backup-start.sh $2"
 elif [ "$1" = "restore" ] ; then
-    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/bin/backup-restore.sh $2"
+    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/backup-restore.sh $2"
 else
     help
 fi

--- a/templates/default/ndb_backup.sh.erb
+++ b/templates/default/ndb_backup.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 help() {
-    echo "usage: $0 backup|restore id "
+    echo "usage: $0 backup|restore id|remove id "
     echo ""
     exit 1
 }
@@ -21,6 +21,8 @@ if [ "$1" = "backup" ] ; then
     su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/backup-start.sh $2"
 elif [ "$1" = "restore" ] ; then
     su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/backup-restore.sh $2"
+elif [ "$1" = "remove" ] ; then
+    su <%= node.ndb.user %> -c "<%= node.ndb.scripts_dir %>/backup-remove.sh $2"
 else
     help
 fi

--- a/templates/default/ndb_backup.sh.erb
+++ b/templates/default/ndb_backup.sh.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+help() {
+    echo "usage: $0 backup|restore id "
+    echo ""
+    exit 1
+}
+
+if [ $# -ne 2  ]; then
+    help
+fi
+
+if [ "$1" = "backup" ] ; then
+    <%= node.ndb.scripts_dir %>/bin/backup-start.sh $2
+elif [ "$1" = "restore" ] ; then
+    <%= node.ndb.scripts_dir %>/bin/backup-restore.sh $2    
+else
+    help
+fi
+
+exit $?

--- a/templates/default/tables.sql.erb
+++ b/templates/default/tables.sql.erb
@@ -1022,7 +1022,7 @@ CREATE TABLE `jupyter_project` (
 -- Backups for MySQL Cluster
 --
 
-CREATE TABLE `ndb_backups` (
+CREATE TABLE `ndb_backup` (
   `backup_id` INT(11) NOT NULL,
   `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`backup_id`)


### PR DESCRIPTION
A new ndb_backups table was added for storing backup_ids and dates.
A new ndb_backup.sh script was added to start/remove a backup. This script needed sudo privileges to change to the 'mysql' user to run it. The script was added to sudoers.d/glassfish to enable this.