### PR TITLE
Add Hopsworks user to Hops group

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -52,6 +52,12 @@ group node["jupyter"]["group"] do
   append true
 end
 
+group node["hops"]["group"] do
+  action :modify
+  members ["#{node["hopsworks"]["user"]}"]
+  append true
+end
+
 directory node["hopsworks"]["dir"]  do
   owner node["hopsworks"]["user"]
   group node["hopsworks"]["group"]


### PR DESCRIPTION
Add Hopsworks user to Hops group in order to be able to create $ZEPPELIN_HOME/Projects directory