### PR TITLE
Build from source with mkl/rdma/mpi support and Centos fixes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -11,7 +11,7 @@ cookbook 'flink', github: "hopshadoop/flink-chef", branch: "master"
 cookbook 'zeppelin', github: "hopshadoop/zeppelin-chef", branch: "master"
 cookbook 'livy', github: "hopshadoop/livy-chef", branch: "master"
 cookbook 'drelephant', github: "hopshadoop/dr-elephant-chef", branch: "master"
-cookbook 'tensorflow', github: "hopshadoop/tensorflow-chef", branch: "master"
+cookbook 'tensorflow', github: "hopshadoop/tensorflow-chef", branch: "centos_cuda"
 
 cookbook 'epipe', github: "hopshadoop/epipe-chef", branch: "master"
 cookbook 'adam', github: "biobankcloud/adam-chef", branch: "master"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -781,7 +781,7 @@ bash "pip_upgrade" do
     user "root"
     code <<-EOF
       set -e
-      pip install --upgrade pip --user
+      pip install --upgrade pip
     EOF
 end
 
@@ -804,10 +804,10 @@ bash "jupyter-sparkmagic" do
     user "root"
     code <<-EOF
     set -e
-    pip install jupyter --user --no-cache-dir 
-    pip install sparkmagic --user --no-cache-dir 
-    pip install urllib3 --user --no-cache-dir 
-    pip install --upgrade requests --user --no-cache-dir 
+    pip install jupyter
+    pip install sparkmagic
+    pip install urllib3
+    pip install --upgrade requests
     jupyter nbextension enable --py --sys-prefix widgetsnbextension
 EOF
 end
@@ -835,8 +835,8 @@ bash "jupyter-pixiedust" do
       export PIXIEDUST_HOME=#{pixiedust_home}
       export SPARK_HOME=#{node['hadoop_spark']['base_dir']}
       export SCALA_HOME=#{scala_home}
-      pip install matplotlib --user --no-cache-dir 
-      pip install pixiedust --user --no-cache-dir 
+      pip install matplotlib
+      pip install pixiedust 
       jupyter pixiedust install --silent
 
 # pythonwithpixiedustspark22 - install in /usr/local/share/jupyter/kernels

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -842,7 +842,7 @@ bash "jupyter-pixiedust" do
 # pythonwithpixiedustspark22 - install in /usr/local/share/jupyter/kernels
       if [ -d /home/#{node["hopsworks"]["user"]}/.local/share/jupyter/kernels ] ; then
 #         chown #{node['hopsworks']['user']} -R /home/#{node["hopsworks"]["user"]}/.local/
-         jupyter-kernelspec install /home/#{node["hopsworks"]["user"]}/.local/share/jupyter/kernels/pythonwithpixiedustspark22
+         jupyter-kernelspec install /home/#{node["hopsworks"]["user"]}/.local/share/jupyter/kernels/pythonwithpixiedustspark2[0-9]
 #         chown #{node['hopsworks']['user']} -R /home/#{node["hopsworks"]["user"]}/.local/share/jupyter/kernels/
       fi
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -14,15 +14,17 @@ mysql_host = my_private_ip()
 password_file = "#{domains_dir}/#{domain_name}_admin_passwd"
 
 
-# For unzipping files
-package "dtrx"
-
 case node.platform
 when "ubuntu"
+
  if node.platform_version.to_f <= 14.04
    node.override["hopsworks"]["systemd"] = "false"
  end
 
+# For unzipping files
+package "dtrx"
+
+ 
  # Needed by sparkmagic
  package "libkrb5-dev"
 


### PR DESCRIPTION
Fixes to build from source for tensorflow including switches for Intel MKL, RDMA, and MPI.
GPU cannot be built from source for centos yet - works for ubuntu.