### PR TITLE
HOPSWORKS-232

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1095,18 +1095,3 @@ template "#{domains_dir}/#{domain_name}/bin/convert-ipython-notebook.sh" do
   action :create
 end
 
-
-bash 'enable_ssl_cert_access' do
-  user "root"
-  if node['install']['user'].empty? 
-    code <<-EOH
-         setfacl -Rm u:#{node['hopsworks']['user']}:rx #{node['kagent']['certs_dir']}
-         setfacl -Rm u:#{node['jupyter']['user']}:rx #{node['kagent']['certs_dir']}
-         EOH
-  else
-    code <<-EOH
-         setfacl -Rm u:#{node['hopsworks']['user']}:rx #{node['kagent']['certs_dir']}
-         EOH
-  end
-end
-

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -78,6 +78,12 @@ user node['jupyter']['user'] do
   not_if "getent passwd #{node['jupyter']['user']}"
 end
 
+group node['kagent']['certs_group'] do
+  action :modify
+  members ["#{node['hopsworks']['user']}", "#{node['jupyter']['user']}"]
+  append true
+end
+
 group node['hops']['group'] do
   action :modify
   members ["#{node['hopsworks']['user']}", "#{node['jupyter']['user']}"]
@@ -385,8 +391,15 @@ ca_dir = node['certs']['dir']
 
 directory ca_dir do
   owner node['glassfish']['user']
-  group node['glassfish']['group']
-  mode "700"
+  group node['kagent']['certs_group']
+  mode "750"
+  action :create
+end
+
+directory "#{ca_dir}/transient" do
+  owner node['glassfish']['user']
+  group node['kagent']['certs_group']
+  mode "750"
   action :create
 end
 


### PR DESCRIPTION
* Add hopsworks and jupyter user to certificates group and remove acl
* Change hops-hadoop-chef repo for testing
* Create transient certificates directory in Chef with correct permissions
* Add forgotten append property to group resource
* Put back upstream hops-hadoop-chef repo

https://hopshadoop.atlassian.net/browse/HOPSWORKS-232