### PR TITLE
[HOPSWORKS-381]  Log HTTP requests and dump them to HDFS periodically

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,7 @@ default['hopsworks']['max_perm_size']            = "1500"
 default['glassfish']['max_perm_size']            = node['hopsworks']['max_perm_size'].to_i
 default['hopsworks']['max_stack_size']           = "1500"
 default['glassfish']['max_stack_size']           = node['hopsworks']['max_stack_size'].to_i
+default['hopsworks']['http_logs']['enabled']     = "true"
 
 
 default['glassfish']['package_url']              = node['download_url'] + "/payara-#{node['glassfish']['version']}.zip"

--- a/metadata.rb
+++ b/metadata.rb
@@ -194,6 +194,9 @@ attribute "hopsworks/max_stack_size",
           :description => "glassfish/max_stack_size",
           :type => 'string'
 
+attribute "hopsworks/http_logs/enabled",
+          :description => "Enable logging of HTTP requests and dump to HDFS",
+          :type => 'string'
 
 attribute "hopsworks/max_perm_size",
           :description => "glassfish/max_perm_size",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -681,6 +681,73 @@ glassfish_asadmin "create-managed-executor-service --enabled=true --longrunningt
 end
 
 
+if node['hopsworks']['http_logs']['enabled'].eql? "true"
+  # Enable http logging
+  glassfish_asadmin "set server.http-service.access-logging-enabled=true" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+
+  # If you change the suffix, you should also change dump_web_logs_to_hdfs.sh.erb file
+  # ':' is not a legal filename character in HDFS, thus '_'
+  glassfish_asadmin "set server.http-service.access-log.rotation-suffix=yyyy-MM-dd-kk_mm" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+
+  glassfish_asadmin "set server.http-service.access-log.max-history-files=10" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+
+  glassfish_asadmin "set server.http-service.access-log.buffer-size-bytes=32768" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+
+  glassfish_asadmin "set server.http-service.access-log.write-interval-seconds=120" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+
+  glassfish_asadmin "set server.http-service.access-log.rotation-interval-in-minutes=1400" do
+   domain_name domain_name
+   password_file "#{domains_dir}/#{domain_name}_admin_passwd"
+   username username
+   admin_port admin_port
+   secure false
+  end
+  
+  # Setup cron job for HDFS dumper
+  cron 'dump_http_logs_to_hdfs' do
+    if node['hopsworks']['systemd'] == "true"
+      command "systemd-cat #{domains_dir}/#{domain_name}/bin/dump_web_logs_to_hdfs.sh"
+    else #sysv
+      command "#{domains_dir}/#{domain_name}/bin/dump_web_logs_to_hdfs.sh >> #{domains_dir}/#{domain_name}/logs/web_dumper.log 2>&1"
+    end
+    user node['glassfish']['user']
+    minute '0'
+    hour '21'
+    day '*'
+    month '*'
+    only_if do File.exist?("#{domains_dir}/#{domain_name}/bin/dump_web_logs_to_hdfs.sh") end
+  end
+end
 
 # Needed by AJP and Shibboleth - https://github.com/payara/Payara/issues/350
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -586,6 +586,19 @@ template "#{theDomain}/bin/start-llap.sh" do
   action :create
 end
 
+template "#{theDomain}/bin/dump_web_logs_to_hdfs.sh" do
+  source "dump_web_logs_to_hdfs.sh.erb"
+  owner node['glassfish']['user']
+  group node['glassfish']['group']
+  mode 0700
+  action :create
+  variables({
+              :weblogs_dir => "#{theDomain}/logs/access",
+              :hadoop_home => node['hops']['base_dir'],
+              :remote_weblogs_dir => "#{node['hops']['hdfs']['user_home']}/#{node['glassfish']['user']}/webserver_logs"
+            })
+end
+
 template "/etc/sudoers.d/glassfish" do
   source "glassfish_sudoers.erb"
   owner "root"

--- a/templates/default/dump_web_logs_to_hdfs.sh.erb
+++ b/templates/default/dump_web_logs_to_hdfs.sh.erb
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+LOGS_DIR=<%= @weblogs_dir %>
+HADOOP_HOME=<%= node['hops']['base_dir'] %>
+HDFS_WEBLOGS_DIR=<%= @remote_weblogs_dir %>
+
+CHECKPOINT=$LOGS_DIR/.checkpoint
+FILES_TO_DUMP=$LOGS_DIR/.files_to_dump
+
+function printer {
+    echo "<Web logs dumper> $1"
+}
+
+if [ -e $CHECKPOINT ]
+then
+    printer "Dumping log files since `cat $CHECKPOINT`"
+    find $LOGS_DIR -type f -name 'server_access_log*' -readable -newer $CHECKPOINT | sort -nr > $FILES_TO_DUMP
+    cp $CHECKPOINT $CHECKPOINT.bak
+else
+    printer "Checkpoint does not exist, dumping all"
+    find $LOGS_DIR -type f -name 'server_access_log*' -readable | sort -nr > $FILES_TO_DUMP
+fi
+
+echo `date` > $CHECKPOINT
+
+# Remove the first file as it is the running log
+sed -i '1d' $FILES_TO_DUMP
+
+function failed_exit {
+    mv $CHECKPOINT.bak $CHECKPOINT
+    exit -1
+}
+
+while IFS='' read -r log_file || [[ -n "$log_file" ]];
+do
+    # Create directory in HDFS
+    date=`echo $log_file | awk -F '.' {'print $2'}`
+    year=`echo $date | awk -F '-' {'print $1'}`
+    month=`echo $date | awk -F '-' {'print $2'}`
+    REMOTE_DIR=$HDFS_WEBLOGS_DIR/$year/$month
+    printer "Creating remote directory $REMOTE_DIR"
+    $HADOOP_HOME/bin/hdfs dfs -mkdir -p $REMOTE_DIR
+    if [ $? -ne 0 ]
+    then
+	printer "Failed to create directory $REMOTE_DIR. Exiting..."
+	failed_exit
+    fi
+    
+    printer "Copying file $log_file"
+    $HADOOP_HOME/bin/hdfs dfs -copyFromLocal $log_file $REMOTE_DIR
+    if [ $? -ne 0 ]
+    then
+        printer "Error while copying $log_file. Exiting..."
+        failed_exit
+    fi
+done < $FILES_TO_DUMP
+
+printer "Deleting temporary files"
+rm $FILES_TO_DUMP
+
+if [ -e $CHECKPOINT.bak ]
+then
+    rm $CHECKPOINT.bak
+fi


### PR DESCRIPTION
[HOPSWORKS-381]  Source hdfs web logs dumper. Missing the remote directory and add it as a cron job

[HOPSWORKS-381]  Enable http logging

[HOPSWORKS-381]  Add cron job to dump log files to hdfs

[HOPSWORKS-381]  Put dummy remote path. I should fix this, just for testing

[HOPSWORKS-381]  Fix name of script in cron job

[HOPSWORKS-381]  Change remote weblogs dir

[HOPSWORKS-381]  Change to testing branches

[HOPSWORKS-381]  Run cron every hour for testing

[HOPSWORKS-381]  Fix in dumper script and consider a non systemd system

[HOPSWORKS-381]  Put back master branches and run cron job daily

https://hopshadoop.atlassian.net/browse/HOPSWORKS-381