### PR TITLE
[Hopsworks-621]

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -63,6 +63,16 @@ attribute "java/install_flavor",
           :display_name =>  "Oracle (default) or openjdk",
           :type => 'string'
 
+attribute "java/jdk/8/x86_64/url",
+          :display_name =>  "Oracle (default) or openjdk",
+          :type => 'string'
+attribute "java/jdk/8/x86_64/checksum",
+          :display_name =>  "Oracle (default) or openjdk",
+          :type => 'string'
+attribute "java/oracle/accept_oracle_download_terms",
+          :display_name =>  "Oracle (default) or openjdk",
+          :type => 'string'
+
 attribute "hopsworks/default/private_ips",
           :description => "ip addrs",
           :type => 'array'


### PR DESCRIPTION
Expose the java recipe attributes to be used in cluster-definitions so we can set the exact java build we want to use.